### PR TITLE
[nrf noup] Add driver_wrapper call for derivation

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -5321,12 +5321,30 @@ static psa_status_t psa_key_agreement_internal( psa_key_derivation_operation_t *
 
     /* Step 1: run the secret agreement algorithm to generate the shared
      * secret. */
-    status = psa_key_agreement_raw_internal( ka_alg,
-                                             private_key,
-                                             peer_key, peer_key_length,
-                                             shared_secret,
-                                             sizeof( shared_secret ),
-                                             &shared_secret_length );
+    psa_key_attributes_t attributes = {
+        .core = private_key->attr
+    };
+
+    status = psa_driver_wrapper_key_agreement( &attributes,
+                                               private_key->key.data,
+                                               private_key->key.bytes,
+                                               peer_key,
+                                               peer_key_length,
+                                               shared_secret,
+                                               sizeof( shared_secret ),
+                                               &shared_secret_length,
+                                               ka_alg );
+
+    if( status == PSA_ERROR_NOT_SUPPORTED )
+    {
+        status = psa_key_agreement_raw_internal( ka_alg,
+                                                 private_key,
+                                                 peer_key, peer_key_length,
+                                                 shared_secret,
+                                                 sizeof( shared_secret ),
+                                                 &shared_secret_length );
+    }
+
     if( status != PSA_SUCCESS )
         goto exit;
 


### PR DESCRIPTION
-This adds a psa_driver_wrapper call for the PSA
 psa_key_derivation_key_agreement API.
 Without this patch the psa_key_derivation APIs
 will never reach the PSA drivers (Oberon, CC3XX)
 and they will only support the software
 implementation. This patch is a noupp because
 we expect the Mbed TLS project to add this
 change in a later release.

Ref: NCSDK-13564

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>