### PR TITLE
DTLS CID Support

### DIFF
--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -1622,7 +1622,20 @@ PREDEFINED             = WIN32 \
                          ENABLE_PLUGIN \
                          ENABLE_MANAGEMENT \
                          ENABLE_OCC \
-                         HAVE_GETTIMEOFDAY
+                         HAVE_GETTIMEOFDAY \
+                         MBEDTLS_SSL_DTLS_CONNECTION_ID \
+                         MBEDTLS_SSL_PROTO_DTLS \
+                         MBEDTLS_SSL_SESSION_TICKETS \
+                         MBEDTLS_SSL_CLI_C \
+                         MBEDTLS_SSL_MAX_FRAGMENT_LENGTH \
+                         MBEDTLS_SSL_ENCRYPT_THEN_MAC \
+                         MBEDTLS_SSL_EXPORT_KEYS \
+                         MBEDTLS_SSL_SERVER_NAME_INDICATION \
+                         MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED \
+                         MBEDTLS_SSL_DTLS_HELLO_VERIFY \
+                         MBEDTLS_SSL_EXTENDED_MASTER_SECRET \
+                         MBEDTLS_DEBUG_C
+
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then
 # this tag can be used to specify a list of macro names that should be expanded.

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -691,7 +691,8 @@
 #endif
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) && \
-        !defined(MBEDTLS_X509_CRT_PARSE_C)
+        !defined(MBEDTLS_X509_CRT_PARSE_C) && \
+        !defined(MBEDTLS_SSL_PROTO_DTLS)
 #error "MBEDTLS_SSL_SERVER_NAME_INDICATION defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -1372,7 +1372,7 @@ struct mbedtls_ssl_context
     /*
      * User settings
      */
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if defined(MBEDTLS_X509_CRT_PARSE_C) || defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
     char *MBEDTLS_PRIVATE(hostname);             /*!< expected peer CN for verification
                                      (and SNI if available)                 */
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
@@ -2944,7 +2944,7 @@ void mbedtls_ssl_conf_sig_hashes( mbedtls_ssl_config *conf,
                                   const int *hashes );
 #endif /* MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED */
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if defined(MBEDTLS_X509_CRT_PARSE_C) || defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 /**
  * \brief          Set or reset the hostname to check against the received
  *                 server certificate. It sets the ServerName TLS extension,
@@ -2964,9 +2964,9 @@ void mbedtls_ssl_conf_sig_hashes( mbedtls_ssl_config *conf,
  *                 On too long input failure, old hostname is unchanged.
  */
 int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname );
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
+#endif /* MBEDTLS_X509_CRT_PARSE_C || MBEDTLS_SSL_SERVER_NAME_INDICATION */
 
-#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
+#if defined(MBEDTLS_X509_CRT_PARSE_C)
 /**
  * \brief          Set own certificate and key for the current handshake
  *
@@ -2997,7 +2997,9 @@ int mbedtls_ssl_set_hs_own_cert( mbedtls_ssl_context *ssl,
 void mbedtls_ssl_set_hs_ca_chain( mbedtls_ssl_context *ssl,
                                   mbedtls_x509_crt *ca_chain,
                                   mbedtls_x509_crl *ca_crl );
+#endif /* MBEDTLS_X509_CRT_PARSE_C */
 
+#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 /**
  * \brief          Set authmode for the current handshake.
  *

--- a/include/mbedtls/ssl.h
+++ b/include/mbedtls/ssl.h
@@ -381,8 +381,12 @@
 
 /* The value of the CID extension is still TBD as of
  * draft-ietf-tls-dtls-connection-id-05
- * (https://tools.ietf.org/html/draft-ietf-tls-dtls-connection-id-05) */
-#define MBEDTLS_TLS_EXT_CID                        254 /* TBD */
+ * (https://tools.ietf.org/html/draft-ietf-tls-dtls-connection-id-05)
+ * Latest CID value is here:
+ * https://www.iana.org/assignments/tls-extensiontype-values/
+ *       tls-extensiontype-values.xhtml#tls-extensiontype-values-1
+ */
+#define MBEDTLS_TLS_EXT_CID                        54
 
 #define MBEDTLS_TLS_EXT_ECJPAKE_KKPP               256 /* experimental */
 

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -696,7 +696,8 @@ static int ssl_populate_transform( mbedtls_ssl_transform *transform,
     const mbedtls_md_info_t *md_info;
 
 #if !defined(MBEDTLS_SSL_EXPORT_KEYS) && \
-    !defined(MBEDTLS_DEBUG_C)
+    !defined(MBEDTLS_DEBUG_C) && \
+    !defined(MBEDTLS_SSL_DTLS_CONNECTION_ID) /* change from: https://github.com/ARMmbed/mbedtls/pull/3991/files */
     ssl = NULL; /* make sure we don't use it except for those cases */
     (void) ssl;
 #endif

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3013,7 +3013,7 @@ static void ssl_handshake_params_init( mbedtls_ssl_handshake_params *handshake )
     mbedtls_x509_crt_restart_init( &handshake->ecrs_ctx );
 #endif
 
-#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
+#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) && defined(MBEDTLS_X509_CRT_PARSE_C)
     handshake->sni_authmode = MBEDTLS_SSL_VERIFY_UNSET;
 #endif
 
@@ -3585,7 +3585,7 @@ void mbedtls_ssl_conf_ca_cb( mbedtls_ssl_config *conf,
 #endif /* MBEDTLS_X509_TRUSTED_CERTIFICATE_CALLBACK */
 #endif /* MBEDTLS_X509_CRT_PARSE_C */
 
-#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
+#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) && defined(MBEDTLS_X509_CRT_PARSE_C)
 int mbedtls_ssl_set_hs_own_cert( mbedtls_ssl_context *ssl,
                                  mbedtls_x509_crt *own_cert,
                                  mbedtls_pk_context *pk_key )
@@ -3607,7 +3607,7 @@ void mbedtls_ssl_set_hs_authmode( mbedtls_ssl_context *ssl,
 {
     ssl->handshake->sni_authmode = authmode;
 }
-#endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION */
+#endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION && MBEDTLS_X509_CRT_PARSE_C */
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
 void mbedtls_ssl_set_verify( mbedtls_ssl_context *ssl,
@@ -3907,7 +3907,7 @@ void mbedtls_ssl_conf_curves( mbedtls_ssl_config *conf,
 }
 #endif /* MBEDTLS_ECP_C */
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if defined(MBEDTLS_X509_CRT_PARSE_C) || defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname )
 {
     /* Initialize to suppress unnecessary compiler warning */
@@ -3951,7 +3951,7 @@ int mbedtls_ssl_set_hostname( mbedtls_ssl_context *ssl, const char *hostname )
 
     return( 0 );
 }
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
+#endif /* MBEDTLS_X509_CRT_PARSE_C || MBEDTLS_SSL_SERVER_NAME_INDICATION */
 
 #if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 void mbedtls_ssl_conf_sni( mbedtls_ssl_config *conf,
@@ -6038,7 +6038,7 @@ void mbedtls_ssl_free( mbedtls_ssl_context *ssl )
         mbedtls_free( ssl->session );
     }
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if defined(MBEDTLS_X509_CRT_PARSE_C) || defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
     if( ssl->hostname != NULL )
     {
         mbedtls_platform_zeroize( ssl->hostname, strlen( ssl->hostname ) );


### PR DESCRIPTION
## Description
This pull request enables Zephyr's mBed TLS 3.0 to utilize DTLS 1.2 Connection IDs compliant with RFC-9146, building on a backport of hannestschofenig's 
https://github.com/Mbed-TLS/mbedtls/pull/5061.

It also makes some minor improvements to the generated Doxygen documentation and makes it possible to use Server Name Indication with DTLS when x509 certs are not required (such as with PSKs).

## Status
**IN DEVELOPMENT**

## Migrations
NO API changes.

## Additional comments
Any additional information that could be of interest

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog updated
- [ ] Backported

