### PR TITLE
[nrf noup] Fix duplicate declaration of ad_len_field

### DIFF
--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -521,7 +521,6 @@ static void ssl_extract_add_data_from_record( unsigned char* add_data,
     size_t ad_len_field = rec->data_len;
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
-    size_t ad_len_field = rec->data_len;
     const unsigned char seq_num_placeholder[] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 #endif /* MBEDTLS_SSL_DTLS_CONNECTION_ID */
 


### PR DESCRIPTION
[nrf noup] Fix duplicate declaration of ad_len_field

MBEDTLS_SSL_DTLS_CONNECTION_ID fails to build now because ad_len_field
is defined twice. Remove the extra one.

Regression from: cf39070d6e3e36e1ed65f970545bf6bcc1b1fc8a
Should be squashed with that commit in next upmerge or rebase.

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>