### PR TITLE
[nrf noup]: Zeroize the Mbedtls entropy mutex

### DIFF
--- a/library/entropy.c
+++ b/library/entropy.c
@@ -54,6 +54,10 @@ void mbedtls_entropy_init( mbedtls_entropy_context *ctx )
     memset( ctx->source, 0, sizeof( ctx->source ) );
 
 #if defined(MBEDTLS_THREADING_C)
+    /* This is a workaround, the CryptoCell runtime library which implements the mutex
+       initialization function expects the mutex context to be zeroized. Otherwise it will
+       generate a fault. See NCSDK-17004 for more information. */
+    memset(&ctx->mutex, 0, sizeof(ctx->mutex));
     mbedtls_mutex_init( &ctx->mutex );
 #endif
 


### PR DESCRIPTION
This makes sure that the content of the mutex
inside the mbedtls_entropy_context is zeroed.
This is a workaround because the CryptoCell
runtime library will generate a fault if
the mutex is not zeroed. This workaround
will be reverted later when NCSDK-17004
is fixed. There is no reason to upstream this
since it is a limitation in our CryptoCell
runtime library and not an upstream limitation.

Ref: NCSDK-8075

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>
