### PR TITLE
[nrf noup] Constant size for psa_core_key_attributes_t struct

### DIFF
--- a/include/psa/crypto_struct.h
+++ b/include/psa/crypto_struct.h
@@ -319,20 +319,44 @@ typedef uint16_t psa_key_attributes_flag_t;
 #define MBEDTLS_PSA_KA_MASK_DUAL_USE (          \
         0 )
 
+/* Only used when the key id doesn't encode the owners id, to fill the reserved
+ * field in psa_core_key_attributes_t
+*/
+#define MBEDTLS_KEY_ATTRIBUTE_RESERVED_INIT (int32_t) 0
+
 typedef struct
 {
     psa_key_type_t MBEDTLS_PRIVATE(type);
     psa_key_bits_t MBEDTLS_PRIVATE(bits);
     psa_key_lifetime_t MBEDTLS_PRIVATE(lifetime);
     mbedtls_svc_key_id_t MBEDTLS_PRIVATE(id);
+/* This ensures that size of struct doesn't change size depending on setting 
+ * MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER 
+ */
+#if !defined(MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER)
+    int32_t  MBEDTLS_PRIVATE(reserved);
+#endif /* !MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER */
     psa_key_policy_t MBEDTLS_PRIVATE(policy);
     psa_key_attributes_flag_t MBEDTLS_PRIVATE(flags);
 } psa_core_key_attributes_t;
 
+/* 
+ * Changing MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER changes the size 
+ * of psa_core_key_attributes_t, which can lead to incompatibilties.
+ * This provides a compatible version of initialisation.
+ */
+#if defined(MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER)
 #define PSA_CORE_KEY_ATTRIBUTES_INIT { PSA_KEY_TYPE_NONE, 0,            \
                                        PSA_KEY_LIFETIME_VOLATILE,       \
                                        MBEDTLS_SVC_KEY_ID_INIT,         \
                                        PSA_KEY_POLICY_INIT, 0 }
+#else
+#define PSA_CORE_KEY_ATTRIBUTES_INIT { PSA_KEY_TYPE_NONE, 0,                \
+                                       PSA_KEY_LIFETIME_VOLATILE,           \
+                                       MBEDTLS_SVC_KEY_ID_INIT,             \
+                                       MBEDTLS_KEY_ATTRIBUTE_RESERVED_INIT, \
+                                       PSA_KEY_POLICY_INIT, 0 }
+#endif /* !MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER */
 
 struct psa_key_attributes_s
 {


### PR DESCRIPTION
Before the size would change depending on if MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER is defined or not. This can cause problems when used in different domains. Example:
MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER can not be enabled if PSA_CRYPTO is enabled. So if building an application as non-secure that uses PSA_CRYPTO MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER will not be defined. causing id to just be psa_key_id_t(4 bytes), but TF-M running on the secure domain needs MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER to be enabled, causing the id field to be a struct that is 8 byte when TF-M is built it is linked to the cc3xx runtime library that is built with MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER not defined. As a result, psa_core_key_attributes_t is interpreted differently within the secure domain.

To just build the provided cc3xx library with MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER enabled is not a real option as the library is meant to be also used for a secure domain-only application, that uses PSA_CRYPTO.

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>

## Status
**For Review**

