### PR TITLE
Mbed TLS fixes for NCS 2.5.0

### DIFF
--- a/library/ssl_msg.c
+++ b/library/ssl_msg.c
@@ -1330,8 +1330,16 @@ int mbedtls_ssl_decrypt_buf( mbedtls_ssl_context const *ssl,
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_STREAM)
     if( ssl_mode == MBEDTLS_SSL_MODE_STREAM )
     {
+        if (rec->data_len < transform->maclen) {
+            MBEDTLS_SSL_DEBUG_MSG(1,
+                                  ("Record too short for MAC:"
+                                   " %" MBEDTLS_PRINTF_SIZET " < %" MBEDTLS_PRINTF_SIZET,
+                                   rec->data_len, transform->maclen));
+            return MBEDTLS_ERR_SSL_INVALID_MAC;
+        }
+
         /* The only supported stream cipher is "NULL",
-         * so there's nothing to do here.*/
+         * so there's no encryption to do here.*/
     }
     else
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_STREAM */

--- a/library/ssl_tls12_server.c
+++ b/library/ssl_tls12_server.c
@@ -3823,6 +3823,11 @@ static int ssl_parse_client_key_exchange( mbedtls_ssl_context *ssl )
         }
 
         /* Store peer's ECDH public key. */
+        MBEDTLS_SSL_DEBUG_MSG(3, ("data_len=%zu sizeof(handshake->ecdh_psa_peerkey)=%zu", data_len, sizeof(handshake->ecdh_psa_peerkey)));
+        if (data_len > sizeof(handshake->ecdh_psa_peerkey)) {
+            MBEDTLS_SSL_DEBUG_MSG(1, ("Invalid data length"));
+            return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
+        }
         memcpy( handshake->ecdh_psa_peerkey, p, data_len );
         handshake->ecdh_psa_peerkey_len = data_len;
 

--- a/library/ssl_tls13_generic.c
+++ b/library/ssl_tls13_generic.c
@@ -1500,6 +1500,9 @@ int mbedtls_ssl_tls13_read_public_ecdhe_share( mbedtls_ssl_context *ssl,
     MBEDTLS_SSL_CHK_BUF_READ_PTR( p, end, peerkey_len );
 
     /* Store peer's ECDH public key. */
+    if (peerkey_len > sizeof(handshake->ecdh_psa_peerkey)) {
+        return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
+    }
     memcpy( handshake->ecdh_psa_peerkey, p, peerkey_len );
     handshake->ecdh_psa_peerkey_len = peerkey_len;
 


### PR DESCRIPTION
This commit contains misc fixes for sdk-mbedtls for NCS 2.5 release

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>
