### PR TITLE
[nrf noup] crypto_adjust_config_dependencies: auto-enable ECB when using builtin CCM/GCM

### DIFF
--- a/include/psa/crypto_adjust_config_dependencies.h
+++ b/include/psa/crypto_adjust_config_dependencies.h
@@ -48,4 +48,16 @@
 #define PSA_WANT_ALG_CMAC 1
 #endif
 
+/* When at least one block cipher (AES, ARIA, Camellia) is accelerated, the
+ * builtin implementation of GCM/CCM calls into legacy gcm/ccm modules first
+ * and then into block_cipher module. The latter will
+ * then dispatch to PSA again to encypt data using block ciphers in ECB mode,
+ * which means we need PSA_WANT_ALG_ECB_NO_PADDING to allow this.
+ */
+#if (defined(PSA_WANT_ALG_GCM) || defined(PSA_WANT_ALG_CCM)) && \
+    (defined(PSA_WANT_KEY_TYPE_AES) || defined(PSA_WANT_KEY_TYPE_ARIA) || \
+     defined(PSA_WANT_KEY_TYPE_CAMELLIA))
+#define PSA_WANT_ALG_ECB_NO_PADDING 1
+#endif
+
 #endif /* PSA_CRYPTO_ADJUST_CONFIG_DEPENDENCIES_H */


### PR DESCRIPTION
The builtin implementation of GCM/CCM can dispatch to PSA block cipher accelerators through the block-cipher module if at least one of these block ciphers is accelerated. In that case we need PSA_WANT_ALG_ECB to be enabled.

Noup because the conditions provoking this are NCS-specific (due to noups in Mbed TLS influencing this behavior) and the fix hasn't yet been merged upstream and will likely end up being slightly different.

Upstream PR #: 9951