### PR TITLE
[nrf noup]: Added sonarcloud properties file

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,36 @@
+# This file is used by the SonarCloud GitHub App to configure the SonarCloud Automatic Analysis.
+# https://sonarcloud.io/project/overview?id=nrfconnect_sdk-mbedtls
+
+# SonarCloud project details
+sonar.projectKey=nrfconnect_sdk-mbedtls
+sonar.organization=nrfconnect
+sonar.projectName=sdk-mbedtls
+sonar.projectVersion=1.0
+
+# Path to sources
+sonar.sources=.
+sonar.exclusions=
+sonar.inclusions=configs/**,include/**,library/**,3rdparty/**
+
+# Path to tests
+sonar.tests=tests
+# sonar.test.exclusions=
+# sonar.test.inclusions=
+
+# Exclusions for copy-paste detection
+# sonar.cpd.exclusions=
+
+# Python version (for python projects only)
+sonar.python.version=3.12
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Pull Request Options
+sonar.pullrequest.github.summary_comment=false
+
+# Language.C
+sonar.cfamily.customTargetArch=arm
+sonar.cfamily.customTargetVendor=unknown
+sonar.cfamily.customTargetSystem=linux
+sonar.cfamily.customTargetEnv=gnueabi


### PR DESCRIPTION
## Description

Added a sonarcloud properties file that describes which directories that should be analyzed, and other properties for Sonarcloud


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** not required
- [x] **3.6 backport** not required
- [x] **2.28 backport** not required
- [x] **tests** not required
