### PR TITLE
[nrf fromtree] Fix unused function warning

### DIFF
--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -2788,8 +2788,14 @@ static int mbedtls_ssl_has_set_hostname_been_called(
 }
 #endif
 
-/* Micro-optimization: don't export this function if it isn't needed outside
- * of this source file. */
+/*
+ * Exported for ssl_client.c when SNI is enabled.  When SNI is off the only
+ * in-file caller is get_hostname_for_verification() which is guarded by
+ * MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED, so compile the function out
+ * entirely when neither macro is defined.
+ */
+#if defined(MBEDTLS_SSL_SERVER_NAME_INDICATION) || \
+    defined(MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED)
 #if !defined(MBEDTLS_SSL_SERVER_NAME_INDICATION)
 static
 #endif
@@ -2800,6 +2806,7 @@ const char *mbedtls_ssl_get_hostname_pointer(const mbedtls_ssl_context *ssl)
     }
     return ssl->hostname;
 }
+#endif /* MBEDTLS_SSL_SERVER_NAME_INDICATION || MBEDTLS_SSL_HANDSHAKE_WITH_CERT_ENABLED */
 
 static void mbedtls_ssl_free_hostname(mbedtls_ssl_context *ssl)
 {


### PR DESCRIPTION

## Description

Commit e61852e ("Access ssl->hostname through abstractions") was modified compared to upstream commit https://github.com/Mbed-TLS/mbedtls/commit/4ac4008fa09e0be09a8bfabbb43c966bcc54119f

Due to this an unused function warning can occur if neither SNI nor handshake is enabled.

Fix this as a noup as the bug doesn't exist in upstream.w sentences describing the overall goals of the pull request's commits.


## PR checklist

Please tick as appropriate and edit the reasons (e.g.: "backport: not needed because this is a new feature")

- [x] **changelog** provided, or not required
- [ ] **3.6 backport** done, or not required
- [ ] **2.28 backport** done, or not required
- [x] **tests** provided, or not required



## Notes for the submitter

Please refer to the [contributing guidelines](https://github.com/Mbed-TLS/mbedtls/blob/development/CONTRIBUTING.md), especially the
checklist for PR contributors.

Help make review efficient:
* Multiple simple commits
  - please structure your PR into a series of small commits, each of which does one thing
* Avoid force-push
  - please do not force-push to update your PR - just add new commit(s)
* See our [Guidelines for Contributors](https://mbed-tls.readthedocs.io/en/latest/reviews/review-for-contributors/) for more details about the review process.
