### PR TITLE
[nrf toup] x509_crt.c: fix unused variable errors

### DIFF
--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -208,7 +208,13 @@ static int x509_profile_check_pk_alg(const mbedtls_x509_crt_profile *profile,
 static int x509_profile_check_key(const mbedtls_x509_crt_profile *profile,
                                   const mbedtls_pk_context *pk)
 {
+
+#if defined(PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_BASIC) || defined(PSA_WANT_KEY_TYPE_ECC_PUBLIC_KEY)
     const mbedtls_pk_type_t pk_alg = mbedtls_pk_get_type(pk);
+#else
+    (void) profile;
+    (void) pk;
+#endif
 
 #if defined(PSA_WANT_KEY_TYPE_RSA_KEY_PAIR_BASIC)
     if (pk_alg == MBEDTLS_PK_RSA || pk_alg == MBEDTLS_PK_RSASSA_PSS) {


### PR DESCRIPTION
To be submitted to upstream Mbed TLS.